### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,8 @@ CommonSolve = "0.2"
 SciMLBase = "2"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ExplicitImports", "Test"]

--- a/src/FiniteVolumeMethod1D.jl
+++ b/src/FiniteVolumeMethod1D.jl
@@ -1,8 +1,8 @@
 module FiniteVolumeMethod1D
 
-using SparseArrays
-using SciMLBase
-using CommonSolve
+using CommonSolve: CommonSolve, solve
+using SciMLBase: SciMLBase, CallbackSet, DiscreteCallback, ODEFunction, ODEProblem
+using SparseArrays: sparse
 
 export FVMGeometry, BoundaryConditions, FVMProblem
 export Dirichlet, Neumann

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 MethodOfLines = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,6 @@
+using ExplicitImports
+using FiniteVolumeMethod1D
+using Test
+
+@test check_no_implicit_imports(FiniteVolumeMethod1D) === nothing
+@test check_no_stale_explicit_imports(FiniteVolumeMethod1D) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ using Test
 using SafeTestsets
 
 @testset "FiniteVolumeMethod1D" begin
+    @safetestset "Explicit Imports" begin
+        include("explicit_imports.jl")
+    end
     @safetestset "FVMGeometry" begin
         include("geometry.jl")
     end


### PR DESCRIPTION
## Summary

- Convert implicit imports to explicit imports in FiniteVolumeMethod1D.jl
- Add ExplicitImports.jl tests to CI to prevent future regressions

## Changes Made

### Source Code (src/FiniteVolumeMethod1D.jl)
Changed from bare `using` statements to explicit imports:
- `using CommonSolve: CommonSolve, solve`
- `using SciMLBase: SciMLBase, CallbackSet, DiscreteCallback, ODEFunction, ODEProblem`
- `using SparseArrays: sparse`

### Test Infrastructure
- Added `test/explicit_imports.jl` with ExplicitImports checks:
  - `check_no_implicit_imports(FiniteVolumeMethod1D)`
  - `check_no_stale_explicit_imports(FiniteVolumeMethod1D)`
- Updated `test/runtests.jl` to include Explicit Imports test suite
- Added ExplicitImports to test dependencies in both Project.toml and test/Project.toml

## Test plan
- [x] ExplicitImports tests pass (2/2 tests)
- [x] Main package still compiles and functions correctly
- [ ] CI passes

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)