### PR TITLE
Spellcheck: fix typos / extend allowlist

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,9 @@
+[files]
+extend-exclude = ["Manifest.toml", "**/Manifest.toml"]
+
 [default.extend-words]
+# Local variable abbreviating "Neumann" boundary condition in test/boundary_conditions.jl
+neum = "neum"
 # Julia-specific functions
 indexin = "indexin"
 findfirst = "findfirst"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,0 @@
-[files]
-extend-exclude = ["Manifest.toml", "**/Manifest.toml"]


### PR DESCRIPTION
Fixes the failing **Spell Check** (`crate-ci/typos@v1.47.0`) CI.

**Root cause:** the repo had both `_typos.toml` (containing only a Manifest exclude) and a comprehensive `.typos.toml` allowlist. `typos` reads `_typos.toml` in preference to `.typos.toml`, so the allowlist was never applied (`typos --dump-config` confirmed `[default.extend-words]` was empty). Spellcheck then failed on `neum`.

**Fix:** consolidate into the single canonical `.typos.toml`:
- Fold the Manifest exclude into `.typos.toml` (the `docs/` and `test/` Manifest.toml are tracked).
- Allowlist `neum` — a local variable abbreviating "Neumann" boundary condition in `test/boundary_conditions.jl` (paired with `dirc` for Dirichlet); a false positive, not a code-identifier change.
- Remove the redundant `_typos.toml` so the allowlist is actually applied.

`typos` now exits 0 with zero findings (verified locally with 1.47.0).

Ignore until reviewed by @ChrisRackauckas.