### PR TITLE
Downgrade: raise SciMLBase compat floor to 2.49 (2.0.0 floor unresolvable with solver stack)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 CommonSolve = "0.2"
 ExplicitImports = "1"
 PrecompileTools = "1"
-SciMLBase = "2, 3.1"
+SciMLBase = "2.49, 3.1"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
The MINIMUM-VERSION (downgrade) job fails. The failure surfaces at the `Pkg.test` sandbox re-resolve, but it is a pure resolution conflict (reproduced locally on Julia 1.10, the LTS downgrade floor):

```
Unsatisfiable requirements detected for package DiffEqBase [2b5f629d]:
 ...
 │   └─restricted by compatibility requirements with SciMLBase [0bca4576]
 │     to versions: [4.0.0-6.6.6, 6.56.0-6.68.2] or uninstalled, leaving only versions: 6.56.0-6.66.0
 │       └─SciMLBase restricted to versions 2.0.0 by an explicit requirement
 └─restricted by compatibility requirements with SciMLBase [0bca4576]
   to versions: 3.13.2-6.53.6 or uninstalled — no versions left
```

and, probing minimal floors directly, `Unsatisfiable ... OrdinaryDiffEqSDIRK [2d112036] ... restricted by SciMLBase to versions: uninstalled`.

**Why the old floor was impossible**

- The package compat is `SciMLBase = "2, 3.1"`, so `julia-downgrade-compat` pins SciMLBase to the floor of the first range, `2.0.0`.
- The test target pulls the full OrdinaryDiffEq / MethodOfLines / ModelingToolkit stack. Those test deps carry no `[compat]`, so they are **not** downgrade-pinned and resolve to recent versions, dragging in a recent DiffEqBase + OrdinaryDiffEq sublibraries.
- Modern DiffEqBase declares SciMLBase lower bounds far above 2.0.0 (registry: DiffEqBase `6.130.1-6.132` -> SciMLBase `2.0.1`, climbing higher for newer DiffEqBase), and OrdinaryDiffEqSDIRK at the resolved version has no SciMLBase 2.0.x in range. So SciMLBase 2.0.0 has an empty intersection with the co-installed solver stack -> Unsatisfiable.

(Master latest-versions CI is unaffected: the Core groups on `julia 1` and `julia lts` pass; this is downgrade-specific.)

**Fix**

Raise the lower bound of the first range: `SciMLBase = "2, 3.1"` -> `SciMLBase = "2.49, 3.1"`. The author intent to support both the 2.x and 3.1 series is preserved; only the unresolvable low end of 2.x is dropped. No upper bound lowered, no test logic touched.

**Resolve verification (local, Julia 1.10 LTS), resolution only**

Mimicking the downgrade pin (SciMLBase pinned to floor, test stack left to resolve):

| SciMLBase floor | result |
| --- | --- |
| 2.0.0 | Unsatisfiable (DiffEqBase / OrdinaryDiffEqSDIRK) |
| 2.0.1 | Unsatisfiable |
| 2.30.0 | Unsatisfiable |
| 2.48.0 | Unsatisfiable |
| **2.49.0** | **RESOLVE SUCCEEDED** |
| 2.50.0 | RESOLVE SUCCEEDED |
| 3.1.0 | RESOLVE SUCCEEDED |

2.49.0 is the smallest co-installable floor with the current solver stack. The full test suite was not run locally; PR CI confirms.

Note: there is a separate, pre-existing QA-group failure on lts (Aqua `project_extras`: Project.toml vs test/Project.toml mismatch) unrelated to this resolution fix.

Ignore until reviewed by @ChrisRackauckas.