### PR TITLE
Release prep: bump to 1.3.0 (minor, not patch, due to julia range narrowing)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FiniteVolumeMethod1D"
 uuid = "cfdabe9e-7cc8-40e3-9725-d80209c3e763"
 authors = ["Daniel VandenHeuvel <danj.vandenheuvel@gmail.com>"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Registered 1.2.0 supports julia = "1" (all of Julia 1.x). A commit over a month ago (#81, canonical CI adoption) narrowed this to julia = "1.10" without a corresponding version bump -- content otherwise unchanged since then except a QA/ExplicitImports-only commit. AutoMerge correctly rejected registering this as a patch (1.2.1) since narrowing Julia support isn't patch-safe. Releasing as 1.3.0 (minor) instead, which is where this narrowing should have been reflected in the first place.