### PR TITLE
Enable rendered public docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,5 +3,9 @@ using JET
 
 run_qa(
     FiniteVolumeMethod1D;
+    api_docs_kwargs = (;
+        rendered = true,
+        rendered_ignore = (:solve,),
+    ),
     explicit_imports = true,
 )


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public API docs QA
- ignore the CommonSolve-owned `solve` reexport while checking package-owned exports

## Validation
- `git diff --check`
- `Runic.main(["--check", "src", "test", "docs/make.jl"])` on Julia +1.10
- direct QA via `julia +1.10 --project=test/qa ... include("test/qa/qa.jl")`: passed, `Quality Assurance | 18/18`
- docs build on Julia +1.10: passed with existing local Documenter warnings only
- full `Pkg.test()` on Julia +1.10: passed

No `[sources]` or path source overrides were added.