### PR TITLE
Bump FiniteVolumeMethod1D to v1.3.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FiniteVolumeMethod1D"
 uuid = "cfdabe9e-7cc8-40e3-9725-d80209c3e763"
 authors = ["Daniel VandenHeuvel <danj.vandenheuvel@gmail.com>"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `FiniteVolumeMethod1D` **v1.3.0 → v1.3.1** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Migrate QA to SciMLTesting 2.4 (#110) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)