### PR TITLE
Raise PrecompileTools floor to 1.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 CommonSolve = "0.2.6"
-PrecompileTools = "1"
+PrecompileTools = "1.2.1"
 SciMLBase = "3.18"
 SparseArrays = "1"
 Test = "1"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` lower-bound bump:

- `PrecompileTools = "1"` → `"1.2.1"`

No library code, tests, or package version were changed.

## Why

`SciMLBase = "3.18"` cannot resolve against PrecompileTools 1.0.0–1.0.1. SciMLBase 3.18.0 declares `PrecompileTools = "1.2.1"`. The declared `"1"` floor is a dead range: Downgrade that pins 1.0.0 is unsatisfiable, so the bound does not describe a loadable environment.

The source uses the 1.0.0-broken import form (`using PrecompileTools: @setup_workload, @compile_workload`).

## Verification

Julia 1.10.11. `Pkg.develop` of FiniteVolumeMethod1D, then `Pkg.add(name="PrecompileTools", version=...)`:

```
# 1.0.0 (old floor)
DEVELOP_OK
RESOLVE_FAIL PrecompileTools=1.0.0
Unsatisfiable requirements detected for package SciMLBase [0bca4576]:
 ├─restricted to versions 3.18.0-3 by FiniteVolumeMethod1D
 └─restricted by compatibility requirements with PrecompileTools to versions: 1.0.0-2.10.0 or uninstalled — no versions left
   └─restricted to versions 1.0.0 by an explicit requirement
```

```
# 1.0.1
DEVELOP_OK
RESOLVE_FAIL PrecompileTools=1.0.1
# same SciMLBase 3.18 vs PrecompileTools 1.0.1 window
```

```
# 1.2.1 (new floor)
DEVELOP_OK
RESOLVE_OK PrecompileTools=1.2.1
LOAD_OK FiniteVolumeMethod1D
```

Not verified: the full test suite, a live `julia-downgrade-compat` run, or GPU.
