### PR TITLE
compat: raise SciMLTesting floor to 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ PrecompileTools = "1.2.1"
 SciMLBase = "3.18"
 SparseArrays = "1"
 Test = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -15,9 +15,11 @@ PrecompileTools = "1.2.1"
 SciMLBase = "3.18"
 SparseArrays = "1"
 Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]


### PR DESCRIPTION
This is a mechanical compat-only PR. Raise every affected root/sublibrary SciMLTesting compat entry from 2.1 to 2.10 so the repository uses the strict SciMLTesting QA defaults. No source, test behavior, or documentation changes are included. Please ignore this draft until reviewed by @ChrisRackauckas. Local git diff --check and typos checks pass.